### PR TITLE
Fix le raccourci macos pour "Show context action"

### DIFF
--- a/intellij/FR.md
+++ b/intellij/FR.md
@@ -145,7 +145,7 @@ Que ce soit pour indiquer la présence de code mort, de code smells, d'erreurs o
 
 Ces actions correctives peuvent être déclenchées en mettant son curseur sur la partie souhaitée, puis en utilisant un raccourci indispensable : 
 
-> Show context action : `ALT`+`⏎` / `⌘⏎` sur macOS
+> Show context action : `ALT`+`⏎` / `⌥⏎` sur macOS
 
 ### Générer du code
 


### PR DESCRIPTION
Hello,

Sauf erreur de ma part, il me semble que le raccourci sur macos pour "Show context action" c'est alt+entrée et pas option+entrée.